### PR TITLE
Updated README file regarding CMake use

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ git clone https://github.com/hannestschofenig/QCBOR.git
 git clone https://github.com/ARMmbed/mbedtls.git
 git clone https://github.com/hannestschofenig/libcsuit.git
 cd libcsuit
-git checkout psa
 ```
 
 Next, build the code using cmake


### PR DESCRIPTION
Reason: Checking out the psa branch is not necessary anymore since the PR was merged already.